### PR TITLE
Remove reliance on unmaintained upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM wyrihaximusnet/github-actions-alpine:3
+FROM alpine:3
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl bash git jq
+
+RUN mkdir /workdir
+WORKDIR /workdir
 
 COPY entrypoint.sh /workdir/entrypoint.sh
 


### PR DESCRIPTION
This is a patch measure before this action will be better optimized, to get it at least running on `arm` based machines.